### PR TITLE
Catch errors at the `tick` level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ server:post('/hello', function(req, res)
     res:send(string.format('Hello %s!', req.body.name))
 end)
 
+-- This endpoint will always return 500
+server:get('/fail', function()
+    assert(false)
+end)
+
 -- define a parameterized GET endpoint, here :name will
 -- be matched on any request /hello/(.+) and whatever
 -- value is after /hello/ will populate `req.params.name`

--- a/luxure/router.lua
+++ b/luxure/router.lua
@@ -25,6 +25,12 @@ function Router:route(req, res)
             return true
         end
     end
+
+    local r, s, a = res.outgoing:getstats()
+    if s == 0 then
+        res:status(404)
+        res:send()
+    end
     return false
 end
 ---Register a single route

--- a/luxure/server.lua
+++ b/luxure/server.lua
@@ -15,7 +15,6 @@ Server.__index = Server
 ---Constructor for a Server
 ---@param socket_mod table This should look something like luasocket
 function Server.new(socket_mod)
-    print('Server.new')
     local base = {
         socket_mod = socket_mod,
         router = Router.new(),

--- a/spec/mock_socket.lua
+++ b/spec/mock_socket.lua
@@ -3,10 +3,21 @@ MockSocket.__index = MockSocket
 
 function MockSocket.new(inner)
     local ret = {
+        recvd = 0,
+        sent = 0,
         inner = inner or {},
+        open = true,
     }
     setmetatable(ret, MockSocket)
     return ret
+end
+
+function MockSocket:getstats()
+    return self.recvd, self.sent
+end
+
+function MockSocket:close()
+    self.open = false
 end
 
 function MockSocket.new_with_preamble(method, path)
@@ -19,11 +30,14 @@ function MockSocket:receive()
     if #self.inner == 0 then
         return nil
     end
-    return table.remove(self.inner, 1)
+    local part = table.remove(self.inner, 1)
+    self.recvd = self.recvd + #(part or "")
+    return part
 end
 
 function MockSocket:send(s)
     self.inner = self.inner or {}
+    self.sent = self.sent + #(s or "")
     table.insert(self.inner, s)
 end
 


### PR DESCRIPTION
This should now handle failures a little better. Automatically returning 500 and 404 in the appropriate places.

The caveat is that it checks that no bytes have been sent on that socket before falling back to the appropriate message.

As of now, the body of the 500 messages, doesn't include any error messages provided by `pcall` primarily because it seems like it would leak a little too much information about the error at hand, mainly because they include file file/line number. It may be a good idea to allow for configuring a "dev mode" that will include these messages as they are helpful for debugging.